### PR TITLE
ChocolateyInstall.ps1: add /exenoupdates flag

### DIFF
--- a/ActivePerl/tools/ChocolateyInstall.ps1
+++ b/ActivePerl/tools/ChocolateyInstall.ps1
@@ -5,7 +5,7 @@ $binRoot = "$env:systemdrive\"
 
 ### Using an environment variable to to define the bin root until we implement YAML configuration ###
 if($env:chocolatey_bin_root -ne $null){$binRoot = join-path $env:systemdrive $env:chocolatey_bin_root}
-$silentArgs = "/quiet TARGETDIR=`"$binRoot`" PERL_PATH=Yes PERL_EXT=Yes"
+$silentArgs = "/exenoupdates /quiet TARGETDIR=`"$binRoot`" PERL_PATH=Yes PERL_EXT=Yes"
 
 $url64bit = 'http://downloads.activestate.com/ActivePerl/releases/5.24.3.2404/ActivePerl-5.24.3.2404-MSWin32-x64-404865.exe'
 $checksum64 = 'cb093acd7e5462ec3450372c76e3f6096a4f6ca75f5c9770a96c9bcf7e35950d'


### PR DESCRIPTION
to prevent installer from updating itself.

Currently, the TLS certificate of https://update.activestate.com/, where the
installer reaches out to check for updates, is expired (it expired on Nov 6th).
However, when TLS verification fails, the installer stalls, instead of failing
or gracefully continuing. Adding the /exenoupdates mitigates this problem by
preventing the installer from checking for updates.